### PR TITLE
added support for tags

### DIFF
--- a/Chaosfile.json
+++ b/Chaosfile.json
@@ -4,5 +4,11 @@
   "enableForASGs": [
   ],
   "disableForASGs": [
+  ],
+  "enableForTags": [
+  	{
+  		"key": "chaos_monkey",
+  		"value": "true"
+  	}
   ]
 }

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -46,6 +46,14 @@ ec2.describeInstances(function(err, data) {
               }
             }
           }
+        } else {
+          if (llamaConfig.enableForTags) {
+            llamaConfig.enableForTags.forEach(function(asgTags) {
+              if (asgTags.key == tag.Key && asgTags.value == tag.Value) {
+                candidates.push(inst);
+              }
+            });
+          }
         }
       });
     });


### PR DESCRIPTION
This PR implements this #17 
Tags are specified by dictionaries inside the array "enableForTags".

When dealing with huge amount of ASGs, you cannot mention all of them, or disable some of them. Even more, if you want to quickly test them, you just need to add a tag, without touching the lambda function anymore.